### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ pureyaml
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/pureyaml/badge/?version=develop
-    :target: https://pureyaml.readthedocs.org/en/develop/?badge=develop
+    :target: https://pureyaml.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 
@@ -57,7 +57,7 @@ Yet another yaml parser, in pure python.
 Features
 --------
 
-- Documentation: https://pureyaml.readthedocs.org
+- Documentation: https://pureyaml.readthedocs.io
 - Open Source: https://github.com/bionikspoon/pureyaml
 - MIT license
 

--- a/docs/source/_partial/readme_features.rst
+++ b/docs/source/_partial/readme_features.rst
@@ -1,7 +1,7 @@
 Features
 --------
 
-- Documentation: https://pureyaml.readthedocs.org
+- Documentation: https://pureyaml.readthedocs.io
 - Open Source: https://github.com/bionikspoon/pureyaml
 - MIT license
 

--- a/docs/source/_partial/readme_title.rst
+++ b/docs/source/_partial/readme_title.rst
@@ -19,7 +19,7 @@ pureyaml
     :alt: Coverage Status
 
 .. image:: https://readthedocs.org/projects/pureyaml/badge/?version=develop
-    :target: https://pureyaml.readthedocs.org/en/develop/?badge=develop
+    :target: https://pureyaml.readthedocs.io/en/develop/?badge=develop
     :alt: Documentation Status
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-"""The full documentation is at https://pureyaml.readthedocs.org."""
+"""The full documentation is at https://pureyaml.readthedocs.io."""
 
 try:
     from setuptools import setup


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
